### PR TITLE
HDI bootstrap script to support params without leading --, remove template for unravel_emr_sensor.sh, use HEADNODE IP, use HEADNODE IP

### DIFF
--- a/hdi/ARM-templates/HDinsight-edge-node-ms/azuredeploy.json
+++ b/hdi/ARM-templates/HDinsight-edge-node-ms/azuredeploy.json
@@ -52,7 +52,7 @@
                 },
                 { "name": "[concat('emptynode','-' ,variables('applicationName2'))]",
                   "uri": "[parameters('scriptActionUri2')]",
-                  "parameters": "--unravel-server 10.10.1.4:3000 --spark-version 2.1.0",
+                  "parameters": "unravel-server 10.10.1.4:3000 spark-version 2.3.0",
                   "roles": ["edgenode"]
             }],
             "uninstallScriptActions": [],

--- a/hdi/hdinsight-unravel-kafka-script-action/unravel_hdi_kafka_bootstrap_nodep.sh
+++ b/hdi/hdinsight-unravel-kafka-script-action/unravel_hdi_kafka_bootstrap_nodep.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 ################################################################################################
-# Unravel for HDInsight Bootstrap Script                                                       #
+# Unravel 4.3, 4.4, and 4.5 for HDInsight Bootstrap Script                                     #
 #                                                                                              #
 # The bootstrap script log is located at /media/ephemeral0/logs/others/node_bootstrap.log      #
 ################################################################################################
@@ -476,8 +476,7 @@ PLATFORM="HDI"
 
 echo "AMBARI_PORT before: ${AMBARI_PORT}"
 
-HEADIP=`ping -c1 headnodehost |grep PING |awk '{print $3}' |tr -d '()'`
-
+HEADIP=`ping -c 1 headnodehost | grep PING | awk '{print $3}' | tr -d '()'`
 [ -z "$AMBARI_HOST" ] && export AMBARI_HOST=$HEADIP
 [ -z "$AMBARI_PORT" ] && export AMBARI_PORT=8080
 

--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0.sh
@@ -1,18 +1,12 @@
 #! /bin/bash
 
 ################################################################################################
-# Unravel for HDInsight Bootstrap Script                                                       #
+# Unravel 4.4 for HDInsight Bootstrap Script                                                   #
 #                                                                                              #
 # The bootstrap script log is located at /media/ephemeral0/logs/others/node_bootstrap.log      #
 ################################################################################################
 
 [ ! -z "$VERBOSE" ] && set -x
-
-
-
-
-
-
 
 # Unravel Integration - common functionality
 
@@ -1630,37 +1624,37 @@ function install() {
                 install_usage
                 exit 0
                 ;;
-            --unravel-server )
+            "unravel-server" | "--unravel-server" )
                 UNRAVEL_SERVER=$1
                 [[ $UNRAVEL_SERVER != *":"* ]] && UNRAVEL_SERVER=${UNRAVEL_SERVER}:3000
                 export UNRAVEL_SERVER
                 shift
                 ;;
-            --unravel-receiver )
+            "unravel-receiver" | "--unravel-receiver" )
                 LRHOST=$1
                 [[ $LRHOST != *":"* ]] && LRHOST=${LRHOST}:4043
                 export LRHOST
                 shift
                 ;;
-            --hive-version )
+            "hive-version" | "--hive-version" )
                 export HIVE_VER_XYZ=$1
                 shift
                 ;;
-            --spark-version )
+            "spark-version" | "--spark-version" )
                 export SPARK_VER_XYZ=$1
                 shift
                 ;;
-            --spark-load-mode )
+            "spark-load-mode" | "--spark-load-mode" )
                 export SPARK_APP_LOAD_MODE=$1
                 shift
                 ;;
-            --env)
+            "env" | "--env")
                 for ENV in "$(echo $1 | tr ',' ' ')"; do
                   eval "export $ENV"
                 done
                 shift
                 ;;
-            --uninstall)
+            "uninstall" | "--uninstall")
                 export UNINSTALL=True
                 shift
                 ;;

--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0_a.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0_a.sh
@@ -1,18 +1,12 @@
 #! /bin/bash
 
 ################################################################################################
-# Unravel for HDInsight Bootstrap Script                                                       #
+# Unravel 4.4 for HDInsight Bootstrap Script                                                   #
 #                                                                                              #
 # The bootstrap script log is located at /media/ephemeral0/logs/others/node_bootstrap.log      #
 ################################################################################################
 
 [ ! -z "$VERBOSE" ] && set -x
-
-
-
-
-
-
 
 # Unravel Integration - common functionality
 
@@ -1709,11 +1703,12 @@ function install() {
 PLATFORM="HDI"
 
 echo "AMBARI_PORT before: ${AMBARI_PORT}"
-
-[ -z "$AMBARI_HOST" ] && export AMBARI_HOST=headnodehost
 [ -z "$AMBARI_PORT" ] && export AMBARI_PORT=8080
-
 echo "AMBARI_PORT after: ${AMBARI_PORT}"
+
+HEADIP=`ping -c 1 headnodehost | grep PING | awk '{print $3}' | tr -d '()'`
+[ -z "$AMBARI_HOST" ] && export AMBARI_HOST=$HEADIP
+echo "AMBARI_HOST: ${AMBARI_HOST}"
 
 AMBARICONFIGS_SH=/var/lib/ambari-server/resources/scripts/configs.sh
 

--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0_nodep.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0_nodep.sh
@@ -1,18 +1,12 @@
 #! /bin/bash
 
 ################################################################################################
-# Unravel for HDInsight Bootstrap Script                                                       #
+# Unravel 4.4 for HDInsight Bootstrap Script                                                   #
 #                                                                                              #
 # The bootstrap script log is located at /media/ephemeral0/logs/others/node_bootstrap.log      #
 ################################################################################################
 
 [ ! -z "$VERBOSE" ] && set -x
-
-
-
-
-
-
 
 # Unravel Integration - common functionality
 
@@ -1709,13 +1703,11 @@ function install() {
 PLATFORM="HDI"
 
 echo "AMBARI_PORT before: ${AMBARI_PORT}"
-
-HEADIP=`ping -c1 headnodehost |grep PING |awk '{print $3}' |tr -d '()'`
-
-[ -z "$AMBARI_HOST" ] && export AMBARI_HOST=$HEADIP
 [ -z "$AMBARI_PORT" ] && export AMBARI_PORT=8080
-
 echo "AMBARI_PORT after: ${AMBARI_PORT}"
+
+HEADIP=`ping -c 1 headnodehost | grep PING | awk '{print $3}' | tr -d '()'`
+[ -z "$AMBARI_HOST" ] && export AMBARI_HOST=$HEADIP
 echo "AMBARI_HOST: ${AMBARI_HOST}"
 
 AMBARICONFIGS_SH=/var/lib/ambari-server/resources/scripts/configs.sh


### PR DESCRIPTION
### Summary
* HDI bootstrap scripts for Kafka and Spark to support params without leading --, which is needed when using azure cli to submit script actions, otherwise it will fail.

* Remove template for unravel_emr_sensor.sh since it's now part of the RPM and unzipped from unravel-emrsensor-pack.zip

* When retrieving configs from Ambari, use the Headnode IP instead of its FQDN in case the name is not properly configured via iptable rules in all hosts.

### Testing
![Screen Shot 2019-03-13 at 5 35 00 PM](https://user-images.githubusercontent.com/43970501/54323542-11b64380-45b7-11e9-931f-987c165f2e5d.png)

### Jira
https://unraveldata.atlassian.net/browse/CLOUD-264