### PR TITLE
CLOUD-270 HDI - Unravel 4.5.0.5 is missing cluster due to incorrect unravel_es.properties file

### DIFF
--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_1.0.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_1.0.sh
@@ -769,7 +769,7 @@ function gen_sensor_properties() {
 # sleep-sec=30
 # unravel-server=127.0.0.1
 # cluster-id=j-default
-# cluster-type=emr
+# cluster-type=hdi
 # chunk-size=20
 EOF
 }

--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_2.0.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_2.0.sh
@@ -764,7 +764,7 @@ function gen_sensor_properties() {
 # sleep-sec=30
 # unravel-server=127.0.0.1
 # cluster-id=j-default
-# cluster-type=emr
+# cluster-type=hdi
 # chunk-size=20
 EOF
 }

--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_2.1.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_2.1.sh
@@ -764,7 +764,7 @@ function gen_sensor_properties() {
 # sleep-sec=30
 # unravel-server=127.0.0.1
 # cluster-id=j-default
-# cluster-type=emr
+# cluster-type=hdi
 # chunk-size=20
 EOF
 }

--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0.sh
@@ -758,7 +758,7 @@ function gen_sensor_properties() {
 # sleep-sec=30
 # unravel-server=127.0.0.1
 # cluster-id=j-default
-# cluster-type=emr
+# cluster-type=hdi
 # chunk-size=20
 EOF
 }

--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0_a.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0_a.sh
@@ -758,7 +758,7 @@ function gen_sensor_properties() {
 # sleep-sec=30
 # unravel-server=127.0.0.1
 # cluster-id=j-default
-# cluster-type=emr
+# cluster-type=hdi
 # chunk-size=20
 EOF
 }

--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0_nodep.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_3.0_nodep.sh
@@ -758,7 +758,7 @@ function gen_sensor_properties() {
 # sleep-sec=30
 # unravel-server=127.0.0.1
 # cluster-id=j-default
-# cluster-type=emr
+# cluster-type=hdi
 # chunk-size=20
 EOF
 }

--- a/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_4.5.sh
+++ b/hdi/hdinsight-unravel-spark-script-action/unravel_hdi_spark_bootstrap_4.5.sh
@@ -758,11 +758,10 @@ function gen_sensor_properties() {
 # debug=false
 # done-dir=/path/to/done/dir
 # sleep-sec=30
-# unravel-server=127.0.0.1
-# cluster-id=j-default
-# cluster-type=emr
 # chunk-size=20
-unravel-server=`echo $UNRAVEL_SERVER | sed -e "s/:.*/:4043/g"`:
+cluster-type=hdi
+cluster-id=`echo $CLUSTER_ID`
+unravel-server=`echo $UNRAVEL_SERVER | sed -e "s/:.*/:4043/g"`
 EOF
 }
 


### PR DESCRIPTION
### Summary
Unravel is unable to detect the proper cluster id since Unravel ES has an incorrect properties file, so it defaults to the "j-DEFAULT" cluster.
This is because there's a small typo in unravel_hdi_spark_bootstrap_4.5.sh when gen_sensor_properties().

### Testing
Verified by running a Script Action, checking the proper configs in /usr/local/unravel_es/etc/unravel_es.properties, and running a Hive & Spark service check to confirm the correct Cluster Id. 

![Screen Shot 2019-03-18 at 1 27 21 PM](https://user-images.githubusercontent.com/43970501/54561324-9c18f180-4981-11e9-9fa3-a9a25ce6b7f9.png)


### Jira
https://unraveldata.atlassian.net/browse/CLOUD-270
